### PR TITLE
Add another flag to skip config validation

### DIFF
--- a/opset/configurator.py
+++ b/opset/configurator.py
@@ -131,7 +131,7 @@ class OpsetNotInitializedError(ValueError):
 
 
 def _should_validate_config() -> bool:
-    return os.getenv(OPSET_UNIT_TEST_FLAG) is not None or os.getenv(OPSET_SKIP_VALIDATION_FLAG) is not None
+    return os.getenv(OPSET_UNIT_TEST_FLAG) is None and os.getenv(OPSET_SKIP_VALIDATION_FLAG) is None
 
 
 class Config(Generic[OpsetSettingsMainModelType]):
@@ -157,7 +157,7 @@ class Config(Generic[OpsetSettingsMainModelType]):
 
         raw_model: OpsetSettingsMainModelType = config_model.model_construct(_opset=self)
 
-        if not _should_validate_config():
+        if _should_validate_config():
             local_config = self._read_yaml_config("local.yml", raise_not_found=False)
 
             declared_config = self._merge_configs(raw_model.model_dump(), local_config)

--- a/opset/configurator.py
+++ b/opset/configurator.py
@@ -29,6 +29,7 @@ from opset.gcp_secret_handler import (
 
 OPSET_CONFIG_FILENAME = ".opset.yml"
 OPSET_UNIT_TEST_FLAG = "UNIT_TEST_FLAG"
+OPSET_SKIP_VALIDATION_FLAG = "OPSET_SKIP_VALIDATION"
 OpsetSettingsMainModelType = TypeVar("OpsetSettingsMainModelType", bound="OpsetSettingsMainModel")
 
 logger = logging.getLogger(__name__)
@@ -129,8 +130,8 @@ class OpsetNotInitializedError(ValueError):
     pass
 
 
-def _check_in_unit_test() -> bool:
-    return os.getenv(OPSET_UNIT_TEST_FLAG) is not None
+def _should_validate_config() -> bool:
+    return os.getenv(OPSET_UNIT_TEST_FLAG) is not None or os.getenv(OPSET_SKIP_VALIDATION_FLAG) is not None
 
 
 class Config(Generic[OpsetSettingsMainModelType]):
@@ -156,7 +157,7 @@ class Config(Generic[OpsetSettingsMainModelType]):
 
         raw_model: OpsetSettingsMainModelType = config_model.model_construct(_opset=self)
 
-        if not _check_in_unit_test():
+        if not _should_validate_config():
             local_config = self._read_yaml_config("local.yml", raise_not_found=False)
 
             declared_config = self._merge_configs(raw_model.model_dump(), local_config)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "opset"
-version = "4.0.0"
+version = "4.0.1"
 description = "A library for simplifying the configuration of Python applications at all stages of deployment."
 license = "Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
Sometimes not in unit test we may want to be able to skip config validation and parsing.

Before opening a PR, make sure that, if relevant:
- [ ] Changes are covered by automated tests.
- [ ] New / updated functions / methods have typehints.
- [ ] READMEs have been updated.
- [ ] The affected parties are / will be notified of incoming breaking changes.
