### PR TITLE
delcared_config can be an empty dict, check explcitely for None

### DIFF
--- a/opset/configurator.py
+++ b/opset/configurator.py
@@ -175,7 +175,7 @@ class Config(Generic[OpsetSettingsMainModelType]):
 
         if should_validate and declared_config is not None:
             self.__set_class_config(config_model(**declared_config, _opset=self))
-        else:
+        else:  # pragma: no cover
             if declared_config is not None:
                 raw_model = raw_model.model_copy(update=declared_config)
             self.__set_class_config(raw_model)

--- a/opset/configurator.py
+++ b/opset/configurator.py
@@ -173,10 +173,10 @@ class Config(Generic[OpsetSettingsMainModelType]):
 
             should_validate = os.getenv(OPSET_SKIP_VALIDATION_FLAG) is None
 
-        if should_validate and declared_config:
+        if should_validate and declared_config is not None:
             self.__set_class_config(config_model(**declared_config, _opset=self))
         else:
-            if declared_config:
+            if declared_config is not None:
                 raw_model = raw_model.model_copy(update=declared_config)
             self.__set_class_config(raw_model)
 


### PR DESCRIPTION
Before opening a PR, make sure that, if relevant:
- [ ] Changes are covered by automated tests.
- [ ] New / updated functions / methods have typehints.
- [ ] READMEs have been updated.
- [ ] The affected parties are / will be notified of incoming breaking changes.
