### PR TITLE
Update opset_config logic to use the config path to retrieve the .opset.yml

### DIFF
--- a/opset/configurator.py
+++ b/opset/configurator.py
@@ -158,7 +158,7 @@ class Config(Generic[OpsetSettingsMainModelType]):
         global _opset_config
         _opset_config = init_opset_config(self.config_path)
 
-        raw_model: OpsetSettingsMainModelType = config_model.model_construct(_opset=self, _config_path=config_path)
+        raw_model: OpsetSettingsMainModelType = config_model.model_construct(_opset=self)
 
         declared_config: dict | None = None
         should_validate = False
@@ -177,7 +177,7 @@ class Config(Generic[OpsetSettingsMainModelType]):
             should_validate = os.getenv(OPSET_SKIP_VALIDATION_FLAG) is None
 
         if should_validate and declared_config is not None:
-            self.__set_class_config(config_model(**declared_config, _opset=self, _config_path=config_path))
+            self.__set_class_config(config_model(**declared_config, _opset=self))
         else:  # pragma: no cover
             if declared_config is not None:
                 raw_model = raw_model.model_copy(update=declared_config)

--- a/opset/configurator.py
+++ b/opset/configurator.py
@@ -34,6 +34,8 @@ OpsetSettingsMainModelType = TypeVar("OpsetSettingsMainModelType", bound="OpsetS
 
 logger = logging.getLogger(__name__)
 
+_opset_config: dict[str, Any] = {}
+
 
 class OpsetSettingsBaseModel(BaseModel):
     @model_validator(mode="before")
@@ -59,10 +61,8 @@ class OpsetSettingsBaseModel(BaseModel):
         if not is_gcp_available() and unprocessed_gcp_secret_keys:
             raise MissingGcpSecretManagerLibrary()
 
-        opset_gcp_config = get_opset_config()
-
         for k in unprocessed_gcp_secret_keys:
-            values[k] = cls._convert_type(retrieve_gcp_secret_value(values[k], opset_gcp_config))
+            values[k] = cls._convert_type(retrieve_gcp_secret_value(values[k], _opset_config))
 
         return values
 
@@ -155,7 +155,10 @@ class Config(Generic[OpsetSettingsMainModelType]):
 
         logger.info(f"Initializing config for {self.app_name}")
 
-        raw_model: OpsetSettingsMainModelType = config_model.model_construct(_opset=self)
+        global _opset_config
+        _opset_config = init_opset_config(self.config_path)
+
+        raw_model: OpsetSettingsMainModelType = config_model.model_construct(_opset=self, _config_path=config_path)
 
         declared_config: dict | None = None
         should_validate = False
@@ -174,7 +177,7 @@ class Config(Generic[OpsetSettingsMainModelType]):
             should_validate = os.getenv(OPSET_SKIP_VALIDATION_FLAG) is None
 
         if should_validate and declared_config is not None:
-            self.__set_class_config(config_model(**declared_config, _opset=self))
+            self.__set_class_config(config_model(**declared_config, _opset=self, _config_path=config_path))
         else:  # pragma: no cover
             if declared_config is not None:
                 raw_model = raw_model.model_copy(update=declared_config)
@@ -390,20 +393,19 @@ class Config(Generic[OpsetSettingsMainModelType]):
                 warnings.warn(f"Environment variable [{env_key}] does not match any possible setting, ignoring.")
 
 
-def get_opset_config() -> dict[str, Any] | None:
+def init_opset_config(config_path: str) -> dict[str, Any]:
     """Search for opset config and load it if it exists.
 
     Returns:
-        Opset Config or None
+        Opset Config or empty dict if no config found.
     """
-    current_dir = os.path.dirname(__file__)
-    config_path = _search_for_config_file(current_dir)
+    config_filepath = _search_for_config_file(config_path)
 
-    if config_path:
-        with open(config_path, "r") as config_file:
+    if config_filepath:
+        with open(config_filepath, "r") as config_file:
             return yaml.load(config_file, Loader=yaml.FullLoader) or {}
 
-    return None
+    return {}
 
 
 def _search_for_config_file(dir_path: str) -> str | None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "opset"
-version = "4.0.5"
+version = "4.0.6"
 description = "A library for simplifying the configuration of Python applications at all stages of deployment."
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/configurator_test.py
+++ b/tests/configurator_test.py
@@ -15,7 +15,7 @@ from pydantic import ValidationError
 from pytest_mock import MockerFixture
 
 from opset import OpsetSettingsBaseModel
-from opset.configurator import Config, OpsetConfigAlreadyInitializedError, get_opset_config, load_logging_config
+from opset.configurator import Config, OpsetConfigAlreadyInitializedError, init_opset_config, load_logging_config
 from opset.utils import mock_config_file
 from tests.utils import MockConfig, clear_env_vars, mock_default_config
 
@@ -247,12 +247,13 @@ def test_gcp_secret_format_with_json_value(mock_retrieve_gcp_secret_value) -> No
 def test_get_opset_config(mocker: MockerFixture) -> None:
     mocker.patch(f"{TESTING_MODULE}.os.path.exists", return_true=True)
     mocker.patch("builtins.open")
+    fake_path = "/fake/path"
     mock_yaml = mocker.patch(f"{TESTING_MODULE}.yaml")
     fake_config = mocker.MagicMock()
     fake_config.configure_mock(gcp_project_mapping={"test": "test-1991"})
     mock_yaml.load = mocker.MagicMock(return_value=fake_config)
 
-    opset_config = get_opset_config()
+    opset_config = init_opset_config(fake_path)
 
     assert opset_config.gcp_project_mapping == {"test": "test-1991"}
 


### PR DESCRIPTION
Update opset_config logic to use the config path to retrieve the .opset.yml

Before opening a PR, make sure that, if relevant:
- [x] Changes are covered by automated tests.
- [ ] New / updated functions / methods have typehints.
- [ ] READMEs have been updated.
- [ ] The affected parties are / will be notified of incoming breaking changes.
